### PR TITLE
Mockup Settings e Scan Tab

### DIFF
--- a/codebase/scanApp/src/app/app-routing.module.ts
+++ b/codebase/scanApp/src/app/app-routing.module.ts
@@ -3,7 +3,11 @@ import { PreloadAllModules, RouterModule, Routes } from '@angular/router';
 
 const routes: Routes = [
   { path: '', loadChildren: './pages/home/home.module#HomePageModule' },
-  { path: 'product', loadChildren: './pages/product/product.module#ProductPageModule' }
+  { path: 'product', loadChildren: './pages/product/product.module#ProductPageModule' },
+  {
+    path: 'scan',
+    loadChildren: '../scan/scan.module#ScanPageModule'
+  }
  
 ];
 

--- a/codebase/scanApp/src/app/pages/cart/cart.page.html
+++ b/codebase/scanApp/src/app/pages/cart/cart.page.html
@@ -4,7 +4,7 @@
     <ion-toolbar color="primary">
       <ion-title>Cart</ion-title>
       <ion-buttons slot="primary">
-        <ion-button routerLink="/tabs/scan" routerDirection="forward">
+        <ion-button routerLink="/scan" routerDirection="forward">
           <ion-icon slot="icon-only" name="barcode"></ion-icon>
         </ion-button>
       </ion-buttons>

--- a/codebase/scanApp/src/app/pages/home/home.module.ts
+++ b/codebase/scanApp/src/app/pages/home/home.module.ts
@@ -11,11 +11,7 @@ const routes: Routes = [
   {
     path: 'tabs',
     component: HomePage,
-    children: [
-      {
-        path: 'scan',
-        loadChildren: '../scan/scan.module#ScanPageModule'
-      },
+    children: [      
       {
         path: 'cart',
         loadChildren: '../cart/cart.module#CartPageModule'
@@ -32,7 +28,7 @@ const routes: Routes = [
   },
   {
     path: '',
-    redirectTo: '/tabs/scan',
+    redirectTo: '/tabs/cart',
     pathMatch: 'full'
   }
 ];

--- a/codebase/scanApp/src/app/pages/home/home.page.html
+++ b/codebase/scanApp/src/app/pages/home/home.page.html
@@ -1,12 +1,7 @@
 <ion-tabs>
 
   <ion-tab-bar slot="bottom,top">
-
-    <ion-tab-button tab="scan">
-      <ion-icon name="barcode"></ion-icon>
-      <ion-label>Scan</ion-label>
-    </ion-tab-button>
-
+    
     <ion-tab-button tab="search">
         <ion-icon name="search"></ion-icon>
         <ion-label>Search</ion-label>

--- a/codebase/scanApp/src/app/pages/scan/scan.page.html
+++ b/codebase/scanApp/src/app/pages/scan/scan.page.html
@@ -1,5 +1,8 @@
 <ion-header>
   <ion-toolbar color="primary">
+    <ion-buttons slot="start">
+      <ion-back-button defaultHref="/tabs/cart"></ion-back-button>
+    </ion-buttons>
     <ion-title>Scan Barcode</ion-title>
   </ion-toolbar>
 </ion-header>

--- a/codebase/scanApp/src/app/pages/settings/settings.page.html
+++ b/codebase/scanApp/src/app/pages/settings/settings.page.html
@@ -5,5 +5,50 @@
 </ion-header>
 
 <ion-content>
+  <ion-card>
+
+    <ion-item>
+      <ion-avatar slot="start">
+        <img src="https://www.italiasera.it/wp-content/uploads/2019/08/Don-Matteo-11-prima-puntata.002_e.jpeg">
+      </ion-avatar>
+      <ion-label class="name-label">
+        <h2>Don Matteo</h2>
+        <p>Parroco Impiccione</p>
+      </ion-label>
+    </ion-item>
+  </ion-card>
+
+  <ion-card>
+    <ion-list>
+      <ion-item>
+        <ion-label>Data Nascita</ion-label>
+        <ion-datetime displayFormat="DD/MM/YYYY" placeholder="Seleziona Data"></ion-datetime>      
+      </ion-item>
+      <ion-item>
+        <ion-label>Nazionalità</ion-label>
+        <ion-label slot="end" style="text-align: right;">Italiana</ion-label>
+      </ion-item>
+      <ion-item>
+        <ion-label>Salute</ion-label>
+        <ion-select placeholder="Scegli">
+          <ion-select-option value="buona">Buona</ion-select-option>
+          <ion-select-option value="obeso">Obeso</ion-select-option>
+          <ion-select-option value="moribondo">Moribondo</ion-select-option>
+        </ion-select>
+      </ion-item>
+      <ion-item>
+        <ion-label>Vegano</ion-label>
+        <ion-toggle></ion-toggle>
+      </ion-item>
+      <ion-item>
+        <ion-label>Vegetariano</ion-label>
+        <ion-toggle></ion-toggle>
+      </ion-item>
+      <ion-item>
+        <ion-label>Celiaco</ion-label>
+        <ion-toggle></ion-toggle>
+      </ion-item>
+    </ion-list>
+  </ion-card>
 
 </ion-content>

--- a/codebase/scanApp/src/app/pages/settings/settings.page.scss
+++ b/codebase/scanApp/src/app/pages/settings/settings.page.scss
@@ -1,0 +1,13 @@
+ion-avatar{
+    width: 128px;
+    height: 128px;
+}
+
+.name-label{
+    text-align: center;    
+}
+
+.name-label h2 {
+    font-size: 20px;
+    text-emphasis: none;
+}


### PR DESCRIPTION
Il mockup per la pagina di settings è stato creato e il tab per la scansione è stato rimosso, dato che ora allo scan ci si accede direttamente dal carrello.